### PR TITLE
chore: dedupe .worktrees entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ node_modules
 dist
 dist-ssr
 *.local
-.worktrees
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
Removes the duplicate `.worktrees` ignore rule. Two entries had landed (a bare `.worktrees` and `.worktrees/`); this keeps the directory-scoped `.worktrees/` and drops the redundant bare one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)